### PR TITLE
Improve Decimal Column Internal Representation

### DIFF
--- a/features/2025-10-20-improve-decimal.md
+++ b/features/2025-10-20-improve-decimal.md
@@ -1,0 +1,221 @@
+# Improve Decimal Column Implementation
+
+**Date:** 2025-10-20
+**Branch:** improve-decimal
+**Status:** ✅ Complete - All tests passing (187 unit + 27 integration)
+
+## Summary
+
+Refactored `ColumnDecimal` to use efficient internal representation based on precision, matching the C++ clickhouse-cpp implementation. Instead of always storing decimals as `i128`, the column now delegates to `ColumnInt32`, `ColumnInt64`, or `ColumnInt128` based on precision.
+
+## Changes
+
+### Core Refactoring
+
+**File:** `src/column/decimal.rs`
+
+#### 1. Changed Internal Data Representation
+
+**Before:**
+```rust
+pub struct ColumnDecimal {
+    type_: Type,
+    precision: usize,
+    scale: usize,
+    data: Vec<i128>, // Always i128 - inefficient!
+}
+```
+
+**After:**
+```rust
+pub struct ColumnDecimal {
+    type_: Type,
+    precision: usize,
+    scale: usize,
+    data: ColumnRef, // Delegates to ColumnInt32/Int64/Int128
+}
+```
+
+#### 2. Precision-Based Column Selection
+
+Matches C++ implementation logic:
+
+```rust
+let data: ColumnRef = if precision <= 9 {
+    Arc::new(ColumnInt32::new(Type::int32()))  // 4 bytes per value
+} else if precision <= 18 {
+    Arc::new(ColumnInt64::new(Type::int64()))  // 8 bytes per value
+} else {
+    Arc::new(ColumnInt128::new(Type::int128())) // 16 bytes per value
+};
+```
+
+#### 3. Simplified I/O Operations
+
+Delegate to underlying column for efficient bulk operations:
+
+**Before:**
+```rust
+fn load_from_buffer(&mut self, buffer: &mut &[u8], rows: usize) -> Result<()> {
+    // Manual byte parsing with match on precision
+    for _ in 0..rows {
+        let value = match bytes_per_value {
+            4 => buffer.get_i32_le() as i128,
+            8 => buffer.get_i64_le() as i128,
+            16 => { /* complex i128 parsing */ }
+            _ => unreachable!(),
+        };
+        self.data.push(value);
+    }
+}
+```
+
+**After:**
+```rust
+fn load_from_buffer(&mut self, buffer: &mut &[u8], rows: usize) -> Result<()> {
+    // Delegate to underlying column - uses efficient bulk copy
+    let data_mut = Arc::get_mut(&mut self.data).expect("Cannot modify shared column");
+    data_mut.load_from_buffer(buffer, rows)
+}
+```
+
+#### 4. Updated Method Implementations
+
+All methods now delegate to the underlying column:
+- `append()` - downcasts and appends to Int32/Int64/Int128
+- `at()` - downcasts and retrieves value, converting to i128
+- `len()`, `is_empty()` - delegates to `data.size()`
+- `clear()`, `reserve()` - delegates to underlying column
+- `append_column()` - delegates column appending
+- `slice()` - delegates slicing to underlying column
+
+## Benefits
+
+### 1. Memory Efficiency
+
+**Precision 9 (Decimal(9,2)):**
+- Before: 16 bytes per value (i128)
+- After: 4 bytes per value (i32)
+- **Savings: 75%**
+
+**Precision 18 (Decimal(18,4)):**
+- Before: 16 bytes per value (i128)
+- After: 8 bytes per value (i64)
+- **Savings: 50%**
+
+**Precision 38 (Decimal(38,10)):**
+- Before: 16 bytes per value (i128)
+- After: 16 bytes per value (i128)
+- **No overhead**
+
+### 2. Performance Improvements
+
+- Leverages existing optimized bulk copy operations from `ColumnVector<T>`
+- Reduces cache pressure with smaller data types
+- Matches wire protocol size exactly (no conversion overhead)
+
+### 3. Code Simplification
+
+- Removed manual byte parsing logic (40+ lines eliminated)
+- Centralized column operations through delegation
+- Easier to maintain - changes to numeric columns automatically apply
+
+## Testing
+
+### Unit Tests Added (16 total)
+
+1. **Type Selection Tests:**
+   - `test_decimal_uses_int32_for_precision_9`
+   - `test_decimal_uses_int64_for_precision_18`
+   - `test_decimal_uses_int128_for_precision_38`
+
+2. **Memory Efficiency Tests:**
+   - `test_decimal_memory_efficiency` - verifies byte-level efficiency
+
+3. **Bulk Copy Tests:**
+   - `test_decimal_bulk_copy_int32` - 5 values
+   - `test_decimal_bulk_copy_int64` - 5 values with large numbers
+   - `test_decimal_bulk_copy_int128` - 5 values with very large numbers
+   - `test_decimal_bulk_copy_large_dataset` - 10,000 values
+
+4. **Operation Tests:**
+   - `test_decimal_append_column` - column concatenation
+   - `test_decimal_slice` - slicing operations
+   - `test_decimal_clear_and_reuse` - clear and reuse
+   - `test_decimal_with_data_constructor` - constructor testing
+
+5. **Existing Tests (maintained):**
+   - `test_parse_decimal`
+   - `test_format_decimal`
+   - `test_decimal_column`
+   - `test_decimal_precision_scale`
+
+### Test Results
+
+✅ **Unit Tests:** 187/187 passed
+✅ **Integration Tests:** 27/27 passed
+
+All existing tests continue to pass, confirming backward compatibility.
+
+## C++ Reference Implementation
+
+Based on `clickhouse-cpp/clickhouse/columns/decimal.cpp`:
+
+```cpp
+ColumnDecimal::ColumnDecimal(size_t precision, size_t scale)
+    : Column(Type::CreateDecimal(precision, scale))
+{
+    if (precision <= 9) {
+        data_ = std::make_shared<ColumnInt32>();
+    } else if (precision <= 18) {
+        data_ = std::make_shared<ColumnInt64>();
+    } else {
+        data_ = std::make_shared<ColumnInt128>();
+    }
+}
+```
+
+Our Rust implementation now mirrors this approach exactly.
+
+## Backward Compatibility
+
+✅ **Public API unchanged** - all existing code using `ColumnDecimal` continues to work
+✅ **Wire format unchanged** - serialization/deserialization remains identical
+✅ **All integration tests pass** - verified with actual ClickHouse server
+
+## Performance Impact
+
+Expected improvements for common use cases:
+
+| Decimal Type | Storage Reduction | Typical Use Case |
+|--------------|-------------------|------------------|
+| Decimal(9,2) | 75% | Currency (e.g., USD with cents) |
+| Decimal(18,4) | 50% | High-precision financial data |
+| Decimal(38,10) | 0% | Maximum precision decimals |
+
+For a table with 1 million Decimal(9,2) values:
+- Before: ~16 MB
+- After: ~4 MB
+- **Memory savings: 12 MB per million rows**
+
+## Files Modified
+
+- `src/column/decimal.rs` - Core implementation refactored
+  - Added imports for `ColumnInt32`, `ColumnInt64`, `ColumnInt128`
+  - Removed `BufMut` import (unused after refactoring)
+  - Simplified all Column trait methods
+  - Added 12 new unit tests
+
+## Related Documentation
+
+See `CLAUDE.md` for context on:
+- Column implementation patterns in this codebase
+- C++ vs Rust delegation patterns
+- Bulk copy safety (reserve() + set_len() pattern)
+
+## Next Steps
+
+This refactoring provides a foundation for similar optimizations:
+- [ ] Consider similar delegation for other complex types
+- [ ] Benchmark real-world performance improvements
+- [ ] Document best practices for column delegation pattern

--- a/src/column/decimal.rs
+++ b/src/column/decimal.rs
@@ -1,5 +1,8 @@
 use super::{
     Column,
+    ColumnInt128,
+    ColumnInt32,
+    ColumnInt64,
     ColumnRef,
 };
 use crate::{
@@ -7,19 +10,21 @@ use crate::{
     Error,
     Result,
 };
-use bytes::{
-    BufMut,
-    BytesMut,
-};
+use bytes::BytesMut;
 use std::sync::Arc;
 
 /// Column for Decimal types with precision and scale
 /// Stores values as integers (scaled by 10^scale)
+///
+/// Uses efficient internal representation based on precision:
+/// - precision <= 9: ColumnInt32 (4 bytes per value)
+/// - precision <= 18: ColumnInt64 (8 bytes per value)
+/// - precision > 18: ColumnInt128 (16 bytes per value)
 pub struct ColumnDecimal {
     type_: Type,
     precision: usize,
     scale: usize,
-    data: Vec<i128>, // Store all decimals as i128 internally
+    data: ColumnRef, // Internally delegates to ColumnInt32/Int64/Int128
 }
 
 impl ColumnDecimal {
@@ -29,34 +34,106 @@ impl ColumnDecimal {
             _ => panic!("ColumnDecimal requires Decimal type"),
         };
 
-        Self { type_, precision, scale, data: Vec::new() }
+        // Choose appropriate storage type based on precision (like C++
+        // implementation)
+        let data: ColumnRef = if precision <= 9 {
+            Arc::new(ColumnInt32::new(Type::int32()))
+        } else if precision <= 18 {
+            Arc::new(ColumnInt64::new(Type::int64()))
+        } else {
+            Arc::new(ColumnInt128::new(Type::int128()))
+        };
+
+        Self { type_, precision, scale, data }
     }
 
     pub fn with_data(mut self, data: Vec<i128>) -> Self {
-        self.data = data;
+        // Convert Vec<i128> to the appropriate column type
+        if self.precision <= 9 {
+            let mut col = ColumnInt32::new(Type::int32());
+            for value in data {
+                col.append(value as i32);
+            }
+            self.data = Arc::new(col);
+        } else if self.precision <= 18 {
+            let mut col = ColumnInt64::new(Type::int64());
+            for value in data {
+                col.append(value as i64);
+            }
+            self.data = Arc::new(col);
+        } else {
+            let mut col = ColumnInt128::new(Type::int128());
+            for value in data {
+                col.append(value);
+            }
+            self.data = Arc::new(col);
+        }
         self
     }
 
     /// Append decimal from string "123.45"
     pub fn append_from_string(&mut self, s: &str) -> Result<()> {
         let value = parse_decimal(s, self.scale)?;
-        self.data.push(value);
+        self.append(value);
         Ok(())
     }
 
     /// Append decimal from i128 (raw scaled value)
     pub fn append(&mut self, value: i128) {
-        self.data.push(value);
+        // Delegate to the underlying column based on precision
+        let data_mut =
+            Arc::get_mut(&mut self.data).expect("Cannot modify shared column");
+
+        if self.precision <= 9 {
+            let col = data_mut
+                .as_any_mut()
+                .downcast_mut::<ColumnInt32>()
+                .expect("Expected ColumnInt32");
+            col.append(value as i32);
+        } else if self.precision <= 18 {
+            let col = data_mut
+                .as_any_mut()
+                .downcast_mut::<ColumnInt64>()
+                .expect("Expected ColumnInt64");
+            col.append(value as i64);
+        } else {
+            let col = data_mut
+                .as_any_mut()
+                .downcast_mut::<ColumnInt128>()
+                .expect("Expected ColumnInt128");
+            col.append(value);
+        }
     }
 
     /// Get decimal at index as i128 (raw scaled value)
     pub fn at(&self, index: usize) -> i128 {
-        self.data[index]
+        if self.precision <= 9 {
+            let col = self
+                .data
+                .as_any()
+                .downcast_ref::<ColumnInt32>()
+                .expect("Expected ColumnInt32");
+            col.at(index) as i128
+        } else if self.precision <= 18 {
+            let col = self
+                .data
+                .as_any()
+                .downcast_ref::<ColumnInt64>()
+                .expect("Expected ColumnInt64");
+            col.at(index) as i128
+        } else {
+            let col = self
+                .data
+                .as_any()
+                .downcast_ref::<ColumnInt128>()
+                .expect("Expected ColumnInt128");
+            col.at(index)
+        }
     }
 
     /// Format decimal at index as string
     pub fn as_string(&self, index: usize) -> String {
-        format_decimal(self.data[index], self.scale)
+        format_decimal(self.at(index), self.scale)
     }
 
     pub fn precision(&self) -> usize {
@@ -68,11 +145,11 @@ impl ColumnDecimal {
     }
 
     pub fn len(&self) -> usize {
-        self.data.len()
+        self.data.size()
     }
 
     pub fn is_empty(&self) -> bool {
-        self.data.is_empty()
+        self.data.size() == 0
     }
 }
 
@@ -82,15 +159,19 @@ impl Column for ColumnDecimal {
     }
 
     fn size(&self) -> usize {
-        self.data.len()
+        self.data.size()
     }
 
     fn clear(&mut self) {
-        self.data.clear();
+        let data_mut =
+            Arc::get_mut(&mut self.data).expect("Cannot modify shared column");
+        data_mut.clear();
     }
 
     fn reserve(&mut self, new_cap: usize) {
-        self.data.reserve(new_cap);
+        let data_mut =
+            Arc::get_mut(&mut self.data).expect("Cannot modify shared column");
+        data_mut.reserve(new_cap);
     }
 
     fn append_column(&mut self, other: ColumnRef) -> Result<()> {
@@ -115,7 +196,10 @@ impl Column for ColumnDecimal {
             });
         }
 
-        self.data.extend_from_slice(&other.data);
+        // Delegate to underlying column's append_column
+        let data_mut =
+            Arc::get_mut(&mut self.data).expect("Cannot modify shared column");
+        data_mut.append_column(other.data.clone())?;
         Ok(())
     }
 
@@ -124,68 +208,17 @@ impl Column for ColumnDecimal {
         buffer: &mut &[u8],
         rows: usize,
     ) -> Result<()> {
-        use bytes::Buf;
-
-        self.data.reserve(rows);
-
-        // Determine storage size based on precision
-        let bytes_per_value = if self.precision <= 9 {
-            4 // Int32
-        } else if self.precision <= 18 {
-            8 // Int64
-        } else {
-            16 // Int128
-        };
-
-        for _ in 0..rows {
-            if buffer.len() < bytes_per_value {
-                return Err(Error::Protocol(
-                    "Not enough data for Decimal".to_string(),
-                ));
-            }
-
-            let value = match bytes_per_value {
-                4 => buffer.get_i32_le() as i128,
-                8 => buffer.get_i64_le() as i128,
-                16 => {
-                    let low = buffer.get_u64_le() as u128;
-                    let high = buffer.get_u64_le() as u128;
-                    ((high << 64) | low) as i128
-                }
-                _ => unreachable!(),
-            };
-
-            self.data.push(value);
-        }
-
-        Ok(())
+        // Delegate to the underlying column - it knows how to load its data
+        // efficiently
+        let data_mut =
+            Arc::get_mut(&mut self.data).expect("Cannot modify shared column");
+        data_mut.load_from_buffer(buffer, rows)
     }
 
     fn save_to_buffer(&self, buffer: &mut BytesMut) -> Result<()> {
-        // Determine storage size based on precision
-        let bytes_per_value = if self.precision <= 9 {
-            4 // Int32
-        } else if self.precision <= 18 {
-            8 // Int64
-        } else {
-            16 // Int128
-        };
-
-        for &value in &self.data {
-            match bytes_per_value {
-                4 => buffer.put_i32_le(value as i32),
-                8 => buffer.put_i64_le(value as i64),
-                16 => {
-                    let low = (value as u128) & 0xFFFFFFFFFFFFFFFF;
-                    let high = ((value as u128) >> 64) & 0xFFFFFFFFFFFFFFFF;
-                    buffer.put_u64_le(low as u64);
-                    buffer.put_u64_le(high as u64);
-                }
-                _ => unreachable!(),
-            }
-        }
-
-        Ok(())
+        // Delegate to the underlying column - it knows how to save its data
+        // efficiently
+        self.data.save_to_buffer(buffer)
     }
 
     fn clone_empty(&self) -> ColumnRef {
@@ -193,19 +226,20 @@ impl Column for ColumnDecimal {
     }
 
     fn slice(&self, begin: usize, len: usize) -> Result<ColumnRef> {
-        if begin + len > self.data.len() {
+        if begin + len > self.data.size() {
             return Err(Error::InvalidArgument(format!(
                 "Slice out of bounds: begin={}, len={}, size={}",
                 begin,
                 len,
-                self.data.len()
+                self.data.size()
             )));
         }
 
-        let sliced_data = self.data[begin..begin + len].to_vec();
-        Ok(Arc::new(
-            ColumnDecimal::new(self.type_.clone()).with_data(sliced_data),
-        ))
+        // Create a new ColumnDecimal with the sliced underlying data
+        let sliced_data = self.data.slice(begin, len)?;
+        let mut result = ColumnDecimal::new(self.type_.clone());
+        result.data = sliced_data;
+        Ok(Arc::new(result))
     }
 
     fn as_any(&self) -> &dyn std::any::Any {
@@ -330,5 +364,293 @@ mod tests {
         let col = ColumnDecimal::new(Type::decimal(18, 4));
         assert_eq!(col.precision(), 18);
         assert_eq!(col.scale(), 4);
+    }
+
+    // Tests for efficient internal representation
+
+    #[test]
+    fn test_decimal_uses_int32_for_precision_9() {
+        // Decimal with precision <= 9 should use ColumnInt32 internally
+        let col = ColumnDecimal::new(Type::decimal(9, 2));
+
+        // Verify the internal column is ColumnInt32
+        assert!(col.data.as_any().is::<ColumnInt32>());
+
+        // Verify we can downcast to ColumnInt32
+        let int32_col = col.data.as_any().downcast_ref::<ColumnInt32>();
+        assert!(int32_col.is_some(), "Expected ColumnInt32 for precision 9");
+    }
+
+    #[test]
+    fn test_decimal_uses_int64_for_precision_18() {
+        // Decimal with precision <= 18 should use ColumnInt64 internally
+        let col = ColumnDecimal::new(Type::decimal(18, 4));
+
+        // Verify the internal column is ColumnInt64
+        assert!(col.data.as_any().is::<ColumnInt64>());
+
+        // Verify we can downcast to ColumnInt64
+        let int64_col = col.data.as_any().downcast_ref::<ColumnInt64>();
+        assert!(int64_col.is_some(), "Expected ColumnInt64 for precision 18");
+    }
+
+    #[test]
+    fn test_decimal_uses_int128_for_precision_38() {
+        // Decimal with precision > 18 should use ColumnInt128 internally
+        let col = ColumnDecimal::new(Type::decimal(38, 10));
+
+        // Verify the internal column is ColumnInt128
+        assert!(col.data.as_any().is::<ColumnInt128>());
+
+        // Verify we can downcast to ColumnInt128
+        let int128_col = col.data.as_any().downcast_ref::<ColumnInt128>();
+        assert!(
+            int128_col.is_some(),
+            "Expected ColumnInt128 for precision 38"
+        );
+    }
+
+    #[test]
+    fn test_decimal_memory_efficiency() {
+        // Verify memory efficiency: precision 9 should use 4 bytes per value
+        let mut col9 = ColumnDecimal::new(Type::decimal(9, 2));
+        for i in 0..1000 {
+            col9.append(i * 100);
+        }
+
+        // Save to buffer and check size
+        let mut buf9 = BytesMut::new();
+        col9.save_to_buffer(&mut buf9).unwrap();
+        assert_eq!(
+            buf9.len(),
+            1000 * 4,
+            "Decimal(9,2) should use 4 bytes per value"
+        );
+
+        // Verify memory efficiency: precision 18 should use 8 bytes per value
+        let mut col18 = ColumnDecimal::new(Type::decimal(18, 4));
+        for i in 0..1000 {
+            col18.append(i * 10000);
+        }
+
+        let mut buf18 = BytesMut::new();
+        col18.save_to_buffer(&mut buf18).unwrap();
+        assert_eq!(
+            buf18.len(),
+            1000 * 8,
+            "Decimal(18,4) should use 8 bytes per value"
+        );
+
+        // Verify memory efficiency: precision 38 should use 16 bytes per value
+        let mut col38 = ColumnDecimal::new(Type::decimal(38, 10));
+        for i in 0..1000 {
+            col38.append(i * 1000000000);
+        }
+
+        let mut buf38 = BytesMut::new();
+        col38.save_to_buffer(&mut buf38).unwrap();
+        assert_eq!(
+            buf38.len(),
+            1000 * 16,
+            "Decimal(38,10) should use 16 bytes per value"
+        );
+    }
+
+    #[test]
+    fn test_decimal_bulk_copy_int32() {
+        // Test bulk copy for Decimal using ColumnInt32 internally
+        let mut col = ColumnDecimal::new(Type::decimal(9, 2));
+
+        // Add test data
+        let test_values = vec![12345, -67890, 0, 100, -200];
+        for &val in &test_values {
+            col.append(val);
+        }
+
+        // Save to buffer
+        let mut buf = BytesMut::new();
+        col.save_to_buffer(&mut buf).unwrap();
+
+        // Load into new column (uses bulk copy internally)
+        let mut col2 = ColumnDecimal::new(Type::decimal(9, 2));
+        let mut reader = &buf[..];
+        col2.load_from_buffer(&mut reader, test_values.len()).unwrap();
+
+        // Verify all values match
+        assert_eq!(col2.len(), test_values.len());
+        for (i, &expected) in test_values.iter().enumerate() {
+            assert_eq!(col2.at(i), expected, "Value mismatch at index {}", i);
+        }
+    }
+
+    #[test]
+    fn test_decimal_bulk_copy_int64() {
+        // Test bulk copy for Decimal using ColumnInt64 internally
+        let mut col = ColumnDecimal::new(Type::decimal(18, 4));
+
+        // Add test data with larger values
+        let test_values =
+            vec![1234567890123, -9876543210987, 0, 100000000, -200000000];
+        for &val in &test_values {
+            col.append(val);
+        }
+
+        // Save to buffer
+        let mut buf = BytesMut::new();
+        col.save_to_buffer(&mut buf).unwrap();
+
+        // Load into new column
+        let mut col2 = ColumnDecimal::new(Type::decimal(18, 4));
+        let mut reader = &buf[..];
+        col2.load_from_buffer(&mut reader, test_values.len()).unwrap();
+
+        // Verify all values match
+        assert_eq!(col2.len(), test_values.len());
+        for (i, &expected) in test_values.iter().enumerate() {
+            assert_eq!(col2.at(i), expected, "Value mismatch at index {}", i);
+        }
+    }
+
+    #[test]
+    fn test_decimal_bulk_copy_int128() {
+        // Test bulk copy for Decimal using ColumnInt128 internally
+        let mut col = ColumnDecimal::new(Type::decimal(38, 10));
+
+        // Add test data with very large values
+        let test_values = vec![
+            123456789012345678901234567890_i128,
+            -987654321098765432109876543210_i128,
+            0,
+            1000000000000000000,
+            -2000000000000000000,
+        ];
+        for &val in &test_values {
+            col.append(val);
+        }
+
+        // Save to buffer
+        let mut buf = BytesMut::new();
+        col.save_to_buffer(&mut buf).unwrap();
+
+        // Load into new column
+        let mut col2 = ColumnDecimal::new(Type::decimal(38, 10));
+        let mut reader = &buf[..];
+        col2.load_from_buffer(&mut reader, test_values.len()).unwrap();
+
+        // Verify all values match
+        assert_eq!(col2.len(), test_values.len());
+        for (i, &expected) in test_values.iter().enumerate() {
+            assert_eq!(col2.at(i), expected, "Value mismatch at index {}", i);
+        }
+    }
+
+    #[test]
+    fn test_decimal_bulk_copy_large_dataset() {
+        // Test bulk copy with 10,000 elements
+        let mut col = ColumnDecimal::new(Type::decimal(9, 2));
+
+        for i in 0..10_000 {
+            col.append(i * 100);
+        }
+
+        // Save to buffer
+        let mut buf = BytesMut::new();
+        col.save_to_buffer(&mut buf).unwrap();
+
+        // Load into new column (uses efficient bulk copy)
+        let mut col2 = ColumnDecimal::new(Type::decimal(9, 2));
+        let mut reader = &buf[..];
+        col2.load_from_buffer(&mut reader, 10_000).unwrap();
+
+        // Verify size and spot check values
+        assert_eq!(col2.len(), 10_000);
+        assert_eq!(col2.at(0), 0);
+        assert_eq!(col2.at(5_000), 5_000 * 100);
+        assert_eq!(col2.at(9_999), 9_999 * 100);
+    }
+
+    #[test]
+    fn test_decimal_append_column() {
+        // Test appending one decimal column to another
+        let mut col1 = ColumnDecimal::new(Type::decimal(9, 2));
+        col1.append(12345);
+        col1.append(67890);
+
+        let mut col2 = ColumnDecimal::new(Type::decimal(9, 2));
+        col2.append(11111);
+        col2.append(22222);
+
+        // Append col2 to col1
+        col1.append_column(Arc::new(col2)).unwrap();
+
+        assert_eq!(col1.len(), 4);
+        assert_eq!(col1.at(0), 12345);
+        assert_eq!(col1.at(1), 67890);
+        assert_eq!(col1.at(2), 11111);
+        assert_eq!(col1.at(3), 22222);
+    }
+
+    #[test]
+    fn test_decimal_slice() {
+        // Test slicing a decimal column
+        let mut col = ColumnDecimal::new(Type::decimal(18, 4));
+        for i in 0..10 {
+            col.append(i * 10000);
+        }
+
+        let sliced = col.slice(2, 5).unwrap();
+        assert_eq!(sliced.size(), 5);
+
+        let sliced_concrete =
+            sliced.as_any().downcast_ref::<ColumnDecimal>().unwrap();
+        assert_eq!(sliced_concrete.at(0), 2 * 10000);
+        assert_eq!(sliced_concrete.at(4), 6 * 10000);
+    }
+
+    #[test]
+    fn test_decimal_clear_and_reuse() {
+        // Test that clear() works correctly and column can be reused
+        let mut col = ColumnDecimal::new(Type::decimal(9, 2));
+        col.append(100);
+        col.append(200);
+        assert_eq!(col.len(), 2);
+
+        col.clear();
+        assert_eq!(col.len(), 0);
+        assert!(col.is_empty());
+
+        // Reuse after clear
+        col.append(300);
+        col.append(400);
+        assert_eq!(col.len(), 2);
+        assert_eq!(col.at(0), 300);
+        assert_eq!(col.at(1), 400);
+    }
+
+    #[test]
+    fn test_decimal_with_data_constructor() {
+        // Test the with_data constructor with different precisions
+        let data = vec![100, 200, 300];
+
+        // Precision 9 (uses Int32)
+        let col9 =
+            ColumnDecimal::new(Type::decimal(9, 2)).with_data(data.clone());
+        assert_eq!(col9.len(), 3);
+        assert_eq!(col9.at(0), 100);
+        assert!(col9.data.as_any().is::<ColumnInt32>());
+
+        // Precision 18 (uses Int64)
+        let col18 =
+            ColumnDecimal::new(Type::decimal(18, 4)).with_data(data.clone());
+        assert_eq!(col18.len(), 3);
+        assert_eq!(col18.at(0), 100);
+        assert!(col18.data.as_any().is::<ColumnInt64>());
+
+        // Precision 38 (uses Int128)
+        let col38 =
+            ColumnDecimal::new(Type::decimal(38, 10)).with_data(data.clone());
+        assert_eq!(col38.len(), 3);
+        assert_eq!(col38.at(0), 100);
+        assert!(col38.data.as_any().is::<ColumnInt128>());
     }
 }


### PR DESCRIPTION
## Summary

Refactored `ColumnDecimal` to use efficient internal representation based on precision, matching the C++ clickhouse-cpp implementation. Instead of always storing decimals as `i128`, the column now delegates to `ColumnInt32`, `ColumnInt64`, or `ColumnInt128` based on precision.

## Changes

- **Internal representation**: Changed from `Vec<i128>` to `ColumnRef` that delegates to appropriate integer column type
- **Type selection**: 
  - precision ≤ 9 → `ColumnInt32` (4 bytes per value)
  - precision ≤ 18 → `ColumnInt64` (8 bytes per value)
  - precision > 18 → `ColumnInt128` (16 bytes per value)
- **Simplified I/O**: Delegates to underlying column's optimized bulk operations
- **Added tests**: 12 new unit tests for type selection, memory efficiency, and bulk copy

## Benefits

### Memory Efficiency
- **Decimal(9,2)**: 75% reduction (16 → 4 bytes)
- **Decimal(18,4)**: 50% reduction (16 → 8 bytes)
- **Decimal(38,10)**: No overhead (16 bytes)

For 1M rows of Decimal(9,2): **12 MB savings**

### Performance
- Leverages existing optimized bulk copy from `ColumnVector<T>`
- Reduced cache pressure with smaller data types
- Matches wire protocol size exactly (no conversion overhead)

### Code Quality
- 40+ lines of manual byte parsing eliminated
- Centralized column operations through delegation
- Easier maintenance

## Testing

✅ **187 unit tests** passing
✅ **27 integration tests** passing
✅ All existing tests maintained (backward compatible)

## C++ Reference

Based on `clickhouse-cpp/clickhouse/columns/decimal.cpp`:

```cpp
ColumnDecimal::ColumnDecimal(size_t precision, size_t scale) {
    if (precision <= 9) {
        data_ = std::make_shared<ColumnInt32>();
    } else if (precision <= 18) {
        data_ = std::make_shared<ColumnInt64>();
    } else {
        data_ = std::make_shared<ColumnInt128>();
    }
}
```

Our Rust implementation now mirrors this approach exactly.

See `features/2025-10-20-improve-decimal.md` for detailed documentation.